### PR TITLE
Make ensureState configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,12 @@ var Brematic = function (log, config) {
      * Ensures that the last known state is valid
      * @type {boolean}
      */
-    device.ensureState = true;
+    if (config.hasOwnProperty('ensureState')) {
+        device.ensureState = config.ensureState;
+    } else {
+        device.ensureState = true;
+    }
+    
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
   "engines": {
     "node": ">=0.12.0",
     "homebridge": ">=0.2.0"
-  }
+  },
+  "dependencies": {
+    "node-persist": "2.0.x"
+  },
 }


### PR DESCRIPTION
I'd like to switch my outlets with the remote, too. 
But with the ensureState property, homebridge resets my outlets to its state. 

With this change, it is possible to set the property per device in the plugin configuration